### PR TITLE
Fix typos and correct minor grammatical mistakes

### DIFF
--- a/_posts/2020-03-12-wtf-is-576i.md
+++ b/_posts/2020-03-12-wtf-is-576i.md
@@ -6,25 +6,25 @@ categories: [Information Technology]
 
 ### WTF is 576i and what does that mean?
 
-576i is a the display specifications for regular format PAL television. It stands for 576 lines vertically, interlaced over 50 fields.
+576i is a display specification for regular format PAL television. It stands for 576 lines vertically, interlaced over 50 fields.
 
 Let's break that down. Before the days of progressive digital video like we have on all modern computers and digital television broadcasts, video for television was encoded using analog standards. There were/are three competing standards for this — NTSC (National Television System Committee), PAL (Phase Alternating Line), and SECAM. SECAM is essentially a slightly modified PAL, so there are two major standards at play here.
 
 #### NTSC or PAL?
 
-Much like which countries drive on which side of the road, wether countries use NTSC or PAL largely depends on their neighbors, and their desired marketability for products and content they make to be used in other countries.
+Much like which countries drive on which side of the road, whether countries use NTSC or PAL largely depends on their neighbors, and their desired marketability for products and content they make to be used in other countries.
 
-Let's have a look at the NTSC and PAL distribution world wide:
+Let's have a look at the NTSC and PAL distribution world-wide:
 
 ![NTSC & PAL distribution](https://upload.wikimedia.org/wikipedia/commons/0/0d/PAL-NTSC-SECAM.svg 'NTSC & PAL distribution')
 
 As we can see, NTSC(-J) dominates in northern, central, and the top half of southern America, and also Japan, which is notable. PAL and its close cousin SECAM dominates everywhere else. If you use the same display standard as your neighbor, this makes it very easy for you to share video products across your markets. You can exchange tapes and video recordings to broadcast on TV. Your game console systems have interchangeable games. So why not make it so everything can use both?
 
-Unfortunately, when you have a standard, everything has to adapt to the standard for the processing chain to work. In a PAL environment, Your video tape is PAL, the VCR is PAL, and your TV is also PAL. If you make a swapping VCR, then you also need multi-format tapes, and a swapping TV as well. This is a huge cost for the consumer, and a huge cost to the industry. As far as the situation was in NTSC and PAL's hey-day, it was just too hard. 
+Unfortunately, when you have a standard, everything has to adapt to the standard for the processing chain to work. In a PAL environment, your video tape is PAL, the VCR is PAL, and your TV is also PAL. If you make a swapping VCR, then you also need multi-format tapes, and a swapping TV as well. This is a huge cost for the consumer, and a huge cost to the industry. As far as the situation was in NTSC and PAL's hey-day, it was just too hard. 
 
-It's _possible_, but not straight-forward to convert between the systems, and video quality is lost in the process, plus, next to no consumer devices are actually able to do this. A PAL game console plays PAL games. A PAL VCR records and plays back PAL video. In recent years we are able to convert with consumer PCs, but we don't use PAL and NTSC now, so its usefulness is passed its used-by date. 
+It's _possible_, but not straight-forward to convert between the systems, and video quality is lost in the process, plus, next to no consumer devices are actually able to do this. A PAL game console plays PAL games. A PAL VCR records and plays back PAL video. In recent years we are able to convert with consumer PCs, but we don't use PAL and NTSC now, so its usefulness has passed its used-by date. 
 
-Another issue here is timing. As we will shortly learn, NTSC and PAL use different frame rates. Converting between them causes video to either speed up (PAL -> NTSC) or slow down (NTSC -> PAL). This if left unchecked can alter runtimes for hour long shows by as much as minutes. Some feature length films shown on TV after conversion were actually 4-10 minutes shorter or longer than their real run time because of the effects. We can mitigate this by changing the frames. For PAL to NTSC this is fine, as we simply drop NTSC's extra frames to make correct the correct PAL frame rate. But for NTSC to PAL, frames have to be repeated to make up the difference. There are lots of techniques to do this, but it still affects the video quality regardless. This has traditionally made NTSC -> PAL transmission easier.
+Another issue here is timing. As we will shortly learn, NTSC and PAL use different frame rates. Converting between them causes video to either speed up (PAL -> NTSC) or slow down (NTSC -> PAL). This, if left unchecked, can alter runtimes for hour long shows by as much as minutes. Some feature length films shown on TV after conversion were actually 4-10 minutes shorter or longer than their real run time due to the effects. We can mitigate this by changing the frames. For PAL to NTSC this is fine, as we simply drop NTSC's extra frames to make the correct PAL frame rate. But for NTSC to PAL, frames have to be repeated to make up the difference. There are lots of techniques to do this, but it still affects the video quality regardless. This has traditionally made NTSC -> PAL transmission easier.
 
 #### What are the actual differences between the two?
 
@@ -40,7 +40,7 @@ Let's look at NTSC first:
 | Refresh rate | 29.976 |
 | Field rate | 59.94 |
 
-But what the heck are lines? I thought video resolution was measured in pixels! - And you'd be right, if we were talking about progressive digital video, however, we're talking about analog video, and there are no pixels here. Analog video is drawn on the screen by an electron gun (sounds cool right?) firing electrons in horizontal lines across the screen. The physical size of theses lines are determined by a combination of the resolution of the video standard in use, and the physical size of the screen, where as many lines are available are displayed to fill the physical screen size. In the case of NTSC, this is 480 lines.
+But what the heck are lines? I thought video resolution was measured in pixels! - And you'd be right, if we were talking about progressive digital video, however, we're talking about analog video, and there are no pixels here. Analog video is drawn on the screen by an electron gun (sounds cool right?) firing electrons in horizontal lines across the screen. The physical size of theses lines is determined by a combination of the resolution of the video standard in use, and the physical size of the screen, where as many lines as are available are displayed to fill the physical screen size. In the case of NTSC, this is 480 lines.
 
 #### Interlacing
 
@@ -58,7 +58,7 @@ An interesting effect is created on scene changes, where two images appear toget
 
 You can mitigate this by converting interlaced video to progressive via conversion tools, which get more and more advanced every day. [Handbrake](https://handbrake.fr/), for example, can do this, and techniques to achieve this with as little information loss as possible via machine learning are also developing, but the issue is that these techniques take time and effort to apply, and most people just don't care. Which means that when they upload their family VHS tapes, old TV shows and other interlaced media, we see the jaggies on YouTube and where-ever else the content gets shared. This has led to minor stigma against interlacing.
 
-The truth of it is that interlacing should die. Displays that can correctly process interlaced content are becoming rarer by the day as virtually every new device since 2010 uses a progressive display. Computers have used progressive displays since their inception, and that wont change anytime soon. This isn't a problem now as we have the ability to have true 60fps video, but it was a cool technique back in the day.
+The truth of it is that interlacing should die. Displays that can correctly process interlaced content are becoming rarer by the day as virtually every new device since 2010 uses a progressive display. Computers have used progressive displays since their inception, and that won't change anytime soon. This isn't a problem now as we have the ability to have true 60fps video, but it was a cool technique back in the day.
 
 #### So what about PAL?
 
@@ -70,11 +70,11 @@ Now that we know what fields and interlacing are, lets look at PAL:
 | Refresh rate | 24.976 |
 | Field rate | 49.94 |
 
-So PAL has more lines but less fields. This means the definition is better, but the motion is less fluid. And, functionally, thats the only difference between NTSC and PAL. They both use interlacing, fields, lines and even the same colour encoding scheme. To most people, they'd struggle to tell the difference if sat down in front of two TVs, one showing NTSC video, and one showing PAL. But the difference is there, and because of it a huge amount of products made between 1970 and 2010 (especially in Japan) come in both PAL and NTSC variants. One example is the Nintendo Wii. If you by a PAL Wii, you need to buy the corresponding PAL Wii games, indicated by the encoding type on the DVD case:
+So PAL has more lines but less fields. This means the definition is better, but the motion is less fluid. And, functionally, thats the only difference between NTSC and PAL. They both use interlacing, fields, lines and even the same colour encoding scheme. To most people, they'd struggle to tell the difference if sat down in front of two TVs, one showing NTSC video, and one showing PAL. But the difference is there, and because of it a huge amount of products made between 1970 and 2010 (especially in Japan) come in both PAL and NTSC variants. One example is the Nintendo Wii. If you by a PAL Wii, you need to buy the corresponding PAL Wii games, as indicated by the encoding type on the DVD case:
 
 ![Wii Party](/assets/img/wiipartypal.jpg "Wii Party")
 
-The Nintendo Wii is actually capable of playing the opposing standard's games, but not without first jailbreaking it and un-region locking it. And even if the games work, the settings menu is borked.
+The Nintendo Wii is actually capable of playing the opposing standards' games, but not without first jailbreaking it and un-region locking it. And even if the games work, the settings menu is borked.
 
 #### You still haven't told me where '576i' comes from!
 
@@ -86,8 +86,8 @@ You can read more about this on [Wikipedia](https://en.wikipedia.org/wiki/Broadc
 
 ##### Bonus: Why are NTSC/PAL's refresh rates 24.976/29.976? Why not 25/30?
 
-This is super-duper complicated to fully explain, so i'll give a brief overview. NTSC and PAL were invented before colour television was a thing. At some point in the 1960s, they decided that colour was feasible and they should include it in television broadcasts, but the problem was, they had constructed wildly expensive NTSC and PAL television networks and they wern't so keen on developing a new system, requiring the whole market to go out and buy new televisions to have _any_ picture, let alone colour. Maintaining two separate encoding schemes was expensive, and they didn't have the radio spectrum nor funds to do it.
+This is super-duper complicated to fully explain, so I'll give a brief overview. NTSC and PAL were invented before colour television was a thing. At some point in the 1960s, they decided that colour was feasible and they should include it in television broadcasts, but the problem was they had constructed wildly expensive NTSC and PAL television networks and they weren't so keen on developing a new system, requiring the whole market to go out and buy new televisions to have _any_ picture, let alone colour. Maintaining two separate encoding schemes was expensive, and they didn't have the radio spectrum nor funds to do it.
 
-The solution was to modify the current system. They had to do it in a way that meant black and white TV's could still watch, but also enable colour to be broadcasted to TV's that did support it. To achieve this, they simply carved a small chunk of spectrum out of the frame rate (precisely 0.02 seconds worth), and dumped the colour information there. This worked to achieve both their goals, as the original TV's just ignored the information. This permanently reduced NTSC and PAL's frame rate for the rest of it's life span.
+The solution was to modify the current system. They had to do it in a way that meant black and white TV's could still watch, but also enable colour to be broadcasted to TV's that did support it. To achieve this, they simply carved a small chunk of spectrum out of the frame rate (precisely 0.024 seconds worth), and dumped the colour information there. This worked to achieve both their goals, as the original TV's just ignored the information. This permanently reduced NTSC and PAL's frame rate for the rest of its life span.
 
 Unlike the issue converting between NTSC and PAL as mentioned earlier, the difference is too small to really affect runtimes so it's not a huge issue when converting to progressive. With the return to progressive, we have returned to the rounded frame rates, and due to NTSC regions dominating video storage and playback design systems, PAL's 25 & 50 frame/field rates respectively are fast becoming a thing of the past.


### PR DESCRIPTION
Resolves #2

I've corrected as many typos as I could spot, and fixed a few small grammatical errors as well. With this, the article should now achieve its full glory without being hampered by mistakes that only a fraction of people would ever notice anyway. 

I also changed the `0.02` to `0.024` in the section discussing the introduction of colour TV and the resulting effects on framerate. I believe it was an error (because `29.976 + 0.02 != 30` and `29.976 + 0.024 == 30`), but I could be missing something due to lack of experience in the field.